### PR TITLE
Attempt to fix relative links

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="/">This Dallas Life</a>
+        <a class="navbar-brand" href="{{ "/" | relative_url }}">This Dallas Life</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
@@ -8,7 +8,7 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
                 <li class="nav-item p-lg-5">
-                    <a class="nav-link" href="/blog">Blog</a>
+                    <a class="nav-link" href="{{ "/blog" | relative_url }}">Blog</a>
                 </li>
                 <li class="nav-item p-lg-5">
                     <a class="nav-link" href="#">Podcast</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
         integrity="sha384-qKXV1j0HvMUeCBQ+QVp7JcfGl760yU08IQ+GpUo5hlbpg51QRiuqHAJz8+BrxE/N"
         crossorigin="anonymous"></script>
 
-    <link href="/styles.css" rel="stylesheet">
+    <link href="{{ "/styles.css" | relative_url }}" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
Merging in #3 broke relative links for the GitHub pages site (https://hexel.github.io/thisdallaslife) because since GH Pages appends the repo name as a path.

Attempting to fix the issue following https://github.com/jekyll/jekyll/issues/332#issuecomment-325096981